### PR TITLE
Add support for checking state containing Immutable.js objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+.rpt2_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Support validating state that contain non-standard JS objects (such as Immutable.js)
+
 ## v0.1.2 (October 31, 2017)
 - Set `lib/index.js` as `main` in package.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,11 @@
       "integrity": "sha512-PrXL+bRnN99QkImsmhGeMurvj4cqb5PZ6ajolWyUa83po2SSxcByElipSTrI9FTu9dr+HpHJdRDkavKPVqeZ5g==",
       "dev": true
     },
+    "@types/jest": {
+      "version": "21.1.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.5.tgz",
+      "integrity": "sha512-HwBIPK96DROvcB4EX5mA7L2nzhZ3sh8AcDSFODB4eG43S3q3d0+oo356J51qCxw9Bbn7G1DOmBmrw6vf+WiGTg=="
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepack": "npm run build && npm test"
   },
   "dependencies": {
+    "@types/jest": "^21.1.5",
     "runtypes": "^0.12.0"
   },
   "devDependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,7 +20,6 @@ describe('When creating the reducer', () => {
 })
 
 describe('When reducing an action', () => {
-
     test('it should return the reduced state unchanged when state doesn\'t match the schema', () => {
         const initialState = 5
 
@@ -40,4 +39,29 @@ describe('When reducing an action', () => {
 
         expect(() => schemaReducer(initialState, 0)).toThrow()
     })
+
+    test('it should snapshot state if the `snapshotState` option is `true`', () => {
+        let statePassedToSchema
+
+        const Schema = {
+            check: (state) => {
+                statePassedToSchema = state
+            }
+        }
+
+        // Note that we don't mutate state here. All we're interested in
+        // in this test is that the state we schema check is not the same
+        // as our initial or final state.
+        const reducer = (state, action) => state
+
+        const initialState = {stuff: {name: 'Fred', age: 22}}
+
+        const schemaReducer = createSchemaReducer(Schema, reducer, {snapshotState: true})
+
+        const finalState = schemaReducer(initialState, {type: 'CHANGE_NAME'})
+
+        expect(statePassedToSchema).not.toBe(initialState)
+        expect(statePassedToSchema).not.toBe(finalState)
+    })
 })
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
-import {Action, Reducer} from 'redux'
+import {AnyAction, Reducer} from 'redux'
 
 export type State = any
 
@@ -20,7 +20,7 @@ export interface CreateSchemaOptions {
      * The runtypes library currently only understands plain
      * javascript objects.
      */
-    snapshotState: Boolean
+    snapshotState?: Boolean
 }
 
 /**
@@ -29,12 +29,12 @@ export interface CreateSchemaOptions {
  * @param schema a `runtypes` object definition
  * @param reducer the reducer to wrap
  */
-const createSchemaReducer = (schema: Runtype, reducer: Reducer<State>, options: CreateSchemaOptions) => {
+const createSchemaReducer = (schema: Runtype, reducer: Reducer<State>, options: CreateSchemaOptions = {}) => {
     if (!schema.check) {
         throw new TypeError('\'schema\' passed to schema reducer isn\'t an instance of a runtypes object.')
     }
 
-    return (currentState: State, action: Action): State => {
+    return (currentState: State, action: AnyAction): State => {
         const state = reducer(currentState, action)
 
         const stateToValidate = options.snapshotState

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,26 @@ export interface Runtype {
     check: (state: State) => void
 }
 
+export interface CreateSchemaOptions {
+    /**
+     * Causes schema validation to JSON serialize/deserialize
+     * the state before schema validation. This is useful if
+     * the final state is composed of non-standard javascript
+     * objects (such as Immutable.js).
+     *
+     * The runtypes library currently only understands plain
+     * javascript objects.
+     */
+    snapshotState: Boolean
+}
+
 /**
  * Creates a new reducer that type-checks the given reducer's resulting state
  * against the given schema.
  * @param schema a `runtypes` object definition
  * @param reducer the reducer to wrap
  */
-const createSchemaReducer = (schema: Runtype, reducer: Reducer<State>) => {
+const createSchemaReducer = (schema: Runtype, reducer: Reducer<State>, options: CreateSchemaOptions) => {
     if (!schema.check) {
         throw new TypeError('\'schema\' passed to schema reducer isn\'t an instance of a runtypes object.')
     }
@@ -24,7 +37,11 @@ const createSchemaReducer = (schema: Runtype, reducer: Reducer<State>) => {
     return (currentState: State, action: Action): State => {
         const state = reducer(currentState, action)
 
-        schema.check(state)
+        const stateToValidate = options.snapshotState
+            ? JSON.parse(JSON.stringify(state))
+            : state
+
+        schema.check(stateToValidate)
 
         return state
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
         "module": "commonjs",
         "target": "es5",
         "sourceMap": true,
-        "outDir": "lib"
+        "outDir": "lib",
+        "types": [
+            "jest"
+        ]
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
A common approach to managing state in Redux is to put immutable objects into the state. This prevents accidental changes to state outside of the regular redux action->reducer->state flow.

This PR adds support for schema checking state containing these types of objects.

 **Linked PRs**: N/A

## Changes
- Add an option to the `createSchemaReducer` that controls whether state is "snapshotted" (serialized and deserialized) before schema checking
- If snapshotting is on, `JSON.stringify()` and then `JSON.parse()` the state to ensure we schema check a plain JS object.

## TODOs
- [ ] Update the documentation
- [x] Add a high-level description of your changes to the CHANGELOG.md
- [ ] The code changes are covered by test cases

## How to test-drive this PR
- (necessary config changes)
- Run `npm test`
- (specific manual steps to test, if any)