### PR TITLE
Add flag to control whether schema failures throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Add option to suppress throwing on validation errors (default == `false`)
+
 ## v0.1.4 (November 3, 2017)
 - Support validating state that contain non-standard JS objects (such as Immutable.js)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-runtypes-schema",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,9 +35,19 @@ describe('When reducing an action', () => {
 
         const reducer = (state, action) => 'invalid state'
 
-        const schemaReducer = createSchemaReducer(Runtypes.Number, reducer)
+        const schemaReducer = createSchemaReducer(Runtypes.Number, reducer, {throwOnValidationFailure: true})
 
         expect(() => schemaReducer(initialState, 0)).toThrow()
+    })
+
+    test('it should _not_ throw when the reduced state doesn\'t match the schema but `throwOnValidationFailure` is `false`', () => {
+        const initialState = 5
+
+        const reducer = (state, action) => 'invalid state'
+
+        const schemaReducer = createSchemaReducer(Runtypes.Number, reducer, {throwOnValidationFailure: false})
+
+        expect(() => schemaReducer(initialState, 0)).not.toThrow()
     })
 
     test('it should snapshot state if the `snapshotState` option is `true`', () => {
@@ -63,5 +73,6 @@ describe('When reducing an action', () => {
         expect(statePassedToSchema).not.toBe(initialState)
         expect(statePassedToSchema).not.toBe(finalState)
     })
+
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,14 @@ export interface CreateSchemaOptions {
      * The runtypes library currently only understands plain
      * javascript objects.
      */
-    snapshotState?: Boolean
+    snapshotState?: Boolean,
+    /**
+     * Controls whether `redux-runtypes-schema` throws when
+     * runtype validation fails.
+     * If `false` the error is still logged using `console.warn`
+     * but no Error is thrown.
+     */
+    throwOnValidationFailure?: Boolean
 }
 
 /**
@@ -41,7 +48,14 @@ const createSchemaReducer = (schema: Runtype, reducer: Reducer<State>, options: 
             ? JSON.parse(JSON.stringify(state))
             : state
 
-        schema.check(stateToValidate)
+        try {
+            schema.check(stateToValidate)
+        } catch (e) {
+            console.error('Schema error while validating Redux state', e)
+            if (options.throwOnValidationFailure) {
+                throw(e)
+            }
+        }
 
         return state
     }


### PR DESCRIPTION
It's useful to have schema checks logged but not always for them to throw and break the app. This is useful for gradually adopting a schema on an existing codebase. 

 **Linked PRs**: _n/a_

## Changes
- Add option `throwOnValidationFailure`
- When checking schema, only throw if `throwOnValidationFailure` is `true`

## TODOs
- [x] Update the documentation
- [x] Add a high-level description of your changes to the CHANGELOG.md
- [x] The code changes are covered by test cases

## How to test-drive this PR
- (necessary config changes)
- Run `npm test`
- (specific manual steps to test, if any)